### PR TITLE
fix: Controller를 명시하지 않아 다른 Bean도 요청하는 오류 해결

### DIFF
--- a/src/test/java/com/mtg/Motugame/user/controller/UserControllerTest.java
+++ b/src/test/java/com/mtg/Motugame/user/controller/UserControllerTest.java
@@ -2,6 +2,7 @@ package com.mtg.Motugame.user.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mtg.Motugame.entity.UserEntity;
+import com.mtg.Motugame.stock.service.StockServiceImpl;
 import com.mtg.Motugame.user.dto.UserDto;
 import com.mtg.Motugame.user.service.UserServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,7 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
-@WebMvcTest
+@WebMvcTest(UserController.class)
 @AutoConfigureMockMvc
 class UserControllerTest {
 


### PR DESCRIPTION
- 기존 Controller를 명시하지 않아 다른 Service까지 bean을 요청해 MockMvc에서 테스트 오류가 발생함
- 이를 수정하기 위해서, 어디 Controller의 테스트인지 명시함