### PR TITLE
feat: stock_info의 FindAll Repository Test 구현 완료

### DIFF
--- a/src/test/java/com/mtg/Motugame/stock/repository/StockInfoRepositoryTest.java
+++ b/src/test/java/com/mtg/Motugame/stock/repository/StockInfoRepositoryTest.java
@@ -1,0 +1,39 @@
+package com.mtg.Motugame.stock.repository;
+
+import com.mtg.Motugame.entity.StockInfoEntity;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DataJpaTest
+@ActiveProfiles("h2")
+class StockInfoRepositoryTest {
+
+    @Autowired
+    private StockInfoRepository stockInfoRepository;
+
+    @Test
+    @DisplayName("모든 주식 정보 가져오기 테스트")
+    public void findAll() {
+        //given
+        StockInfoEntity stockInfo = StockInfoEntity.builder()
+                .stockCode("123456")
+                .stockName("삼성전자")
+                .build();
+        stockInfoRepository.save(stockInfo);
+
+        //when
+        List<StockInfoEntity> stockList = stockInfoRepository.findAll();
+
+        //then
+        Assertions.assertThat(stockList.size()).isEqualTo(1);
+    }
+
+}


### PR DESCRIPTION
- `findAll()` 에 대한 사용만 있어, 다음 메서드에대한 `@DataJpaTest`를 구현했습니다