### PR TITLE
fix: JPA Auditing에 대한 Bean 추가

### DIFF
--- a/src/test/java/com/mtg/Motugame/stock/controller/StockControllerTest.java
+++ b/src/test/java/com/mtg/Motugame/stock/controller/StockControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.BDDMockito.given;
@@ -27,6 +28,7 @@ import java.util.List;
 
 @WebMvcTest(StockController.class)
 @AutoConfigureMockMvc
+@MockBean(JpaMetamodelMappingContext.class)
 class StockControllerTest {
 
     @MockBean


### PR DESCRIPTION
- JPA Auditing을 사용했을때, Controller 단에서는 JpaAuditing에 대한 Bean을 불러오지 않아서, 오류가 생기는 것을 확인했습니다. 
- 이를 위해서 controller를 테스트 할때, 모든 Bean을 불러오지 않기 때문에 수정하기위해, `@MockBean(JpaMetamodelMappingContext.class)` 를 Controller 클래스에 붙여주기를 바랍니다.