### PR TITLE
fix: Bigdecimal에서 숫자가 나누어떨어지지 않아 오류가 발생하는 경우 수정

### DIFF
--- a/src/main/java/com/mtg/Motugame/stock/service/StockServiceImpl.java
+++ b/src/main/java/com/mtg/Motugame/stock/service/StockServiceImpl.java
@@ -105,7 +105,7 @@ public class StockServiceImpl implements StockService {
             return 0.0;
         }
 
-        return totalProfit.divide(new BigDecimal(String.valueOf(stockInfoEntity.getScoreRecords().size()))).doubleValue();
+        return totalProfit.divide(new BigDecimal(String.valueOf(stockInfoEntity.getScoreRecords().size())),2).doubleValue();
     }
 
     private List<String> convertSeedsToIndex(List<String> seeds) {


### PR DESCRIPTION
- Bigdecimal의 특성을 반영하지 못하고 divide를 적용해, 나누어 떨어지지 않을 경우 오류가 발생하는 문제점 파악 
<img width="1167" alt="image" src="https://user-images.githubusercontent.com/74089271/213843657-3f1c9676-ad07-4da7-9160-3b461d31b394.png">
